### PR TITLE
fix(rules): relax label-has-associated-control

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,13 @@ module.exports = {
   },
   plugins: ['react-hooks'],
   rules: {
+    'jsx-a11y/label-has-associated-control': [
+      'error',
+      {
+        assert: 'either',
+      },
+    ],
+    'jsx-a11y/label-has-for': 'off',
     'react/destructuring-assignment': 'off',
     'react/jsx-filename-extension': 'off',
     'react-hooks/rules-of-hooks': 'error',


### PR DESCRIPTION
Changes the jsx-a11y/label-has-associated-control rule settings to allow either nesting or `htmlFor` rather than both. Also disables the deprecated jsx-a11y/label-has-for rule.